### PR TITLE
Add Selection Sort to DIRECTORY.md

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -1,8 +1,9 @@
 ## Sorts
  * [Bubble Sort](https://github.com/TheAlgorithms/Haskell/blob/master/src/Sorts/BubbleSort.hs)
+ * [Insertion Sort](https://github.com/TheAlgorithms/Haskell/blob/master/src/Sorts/InsertionSort.hs)
  * [Merge Sort](https://github.com/TheAlgorithms/Haskell/blob/master/src/Sorts/MergeSort.hs)
  * [Quick Sort](https://github.com/TheAlgorithms/Haskell/blob/master/src/Sorts/QuickSort.hs)
- * [Insertion Sort](https://github.com/TheAlgorithms/Haskell/blob/master/src/Sorts/InsertionSort.hs)
+ * [Selection Sort](https://github.com/TheAlgorithms/Haskell/blob/master/src/Sorts/SelectionSort.hs)
 
 ## Robotics
  * [Complementary Filter](https://github.com/TheAlgorithms/Haskell/blob/master/src/Robotics/ComplementaryFilter/CompFilt.hs)


### PR DESCRIPTION
The PR that added Selection Sort (#5) did not add a link to the DIRECTORY. 

I have added it here, and also sorted (haha) the sorting algorithm names alphabetically.