### PR TITLE
Generalize container of statistics algorithms.

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -21,6 +21,8 @@ library:
   - base
   - sort
   - containers
+  - vector
+  - vector-algorithms
   source-dirs: src
 
 tests:

--- a/src/Statistics/Center.hs
+++ b/src/Statistics/Center.hs
@@ -1,22 +1,49 @@
 module Statistics.Center where
 
 import qualified Data.Sort as S
+import qualified Data.Vector.Generic as VG
+import qualified Data.Vector.Algorithms.Intro as VGAI
 
 -- Measures of central tendency.
 
-arithmeticMean :: (Fractional a) => [a] -> a
-arithmeticMean vals = (sum vals)/(fromIntegral $ length vals)
+arithmeticMean :: (Foldable t, Fractional a) => t a -> a
+arithmeticMean vals = (sum vals) / (fromIntegral $ length vals)
 
-geometricMean :: (Floating a) => [a] -> a
+geometricMean :: (Foldable t, Floating a) => t a -> a
 geometricMean vals = (product vals) ** (1/(fromIntegral $ length vals))
 
-harmonicMean :: (Fractional a) => [a] -> a
-harmonicMean vals = (sum $ map (1/) vals)/(fromIntegral $ length vals)
+harmonicMean :: (Foldable t, Functor t, Fractional a) => t a -> a
+harmonicMean vals = (sum $ fmap (1/) vals) / (fromIntegral $ length vals)
 
-median :: (Fractional a, Ord a) => [a] -> a
-median vals = if odd n 
-              then head $ drop mid sortedVals 
-              else arithmeticMean $ take 2 $ drop (mid-1) sortedVals
-    where sortedVals = (S.sort vals)
-          n = length vals
-          mid = n `div` 2 
+-- For median, since the containers are sorted differently, we need to use
+-- different methods
+
+medianList :: (Fractional a, Ord a) => [a] -> a
+medianList = medianListSorted . S.sort
+
+medianVector
+  :: (VG.Vector vector a, Foldable vector, Fractional a, Ord a)
+  => vector a -> a
+medianVector = medianVectorSorted . VG.modify VGAI.sort
+
+-- When sorted, the two median algorithms are quite similar. We can reduce
+-- duplication by adding an export list to the module and using more
+-- higher-order functions but let's leave this for a different PR.
+
+medianListSorted :: Fractional a => [a] -> a
+medianListSorted vals
+  | odd n = vals !! mid
+  | otherwise = arithmeticMean $ take 2 $ drop (mid - 1) vals
+  where
+    n = length vals
+    mid = n `div` 2
+
+medianVectorSorted
+  :: (VG.Vector vector a, Foldable vector, Fractional a)
+  => vector a -> a
+medianVectorSorted vals
+  | odd n = vals VG.! mid
+  | otherwise = arithmeticMean $ VG.take 2 $ VG.drop (mid - 1) vals
+  where
+    n = length vals
+    mid = n `div` 2

--- a/src/Statistics/Dispersion.hs
+++ b/src/Statistics/Dispersion.hs
@@ -2,11 +2,11 @@ module Statistics.Dispersion where
 
 import Statistics.Center
 
-variance :: (Fractional a) => [a] -> a
-variance vals = (sum $ zipWith (*) deviations deviations)/n
+variance :: (Foldable t, Functor t, Fractional a) => t a -> a
+variance vals = (sum $ fmap (\x -> x * x) deviations) / n
     where n = (fromIntegral $ length vals)
           mu = arithmeticMean vals
-          deviations = map (\x -> x-mu) vals
+          deviations = fmap (\x -> x-mu) vals
 
-stdev :: (Floating a) => [a] -> a
+stdev :: (Foldable t, Functor t, Floating a) => t a -> a
 stdev vals = sqrt $ variance vals


### PR DESCRIPTION
As written, the statistics algorithms only work on standard lists. However, Haskell lists are very inefficient and most production code uses `Vector` or `Array`. We can generalize these functions by mostly changing the type signature.

Added a few more methods for median due to the fact that this algorithm cannot be generalized due to different sorting implementations. However, this also results in adding functions for finding the median of already sorted arrays which can result in better complexity if the input is guaranteed to be sorted.